### PR TITLE
Remove localhost livereload.js script reference

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -20,7 +20,6 @@
     <link rel="stylesheet" href="/assets/fonts/font-awesome/css/font-awesome.css">
 
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:300,700,700italic,300italic|Open+Sans:700,400" />
-    <script src="//localhost:35729/livereload.js"></script>
     {{! Ghost outputs important style and meta data with this tag }}
     {{ghost_head}}
 </head>


### PR DESCRIPTION
This was killing the load time for mobile.
